### PR TITLE
Add setting and popup to confirm plate cleared

### DIFF
--- a/components/bambuddy_api/bambuddy_api.cpp
+++ b/components/bambuddy_api/bambuddy_api.cpp
@@ -436,6 +436,9 @@ void BambuddyAPIComponent::http_task_loop() {
         case HttpJob::ARCHIVE_SPOOL:
           api_archive_spool(job.i1);
           break;
+        case HttpJob::CLEAR_PLATE:
+          api_clear_plate(job.s1);
+          break;
       }
     }
 
@@ -1823,8 +1826,10 @@ void BambuddyAPIComponent::api_get_printer_status(const std::string &printer_id)
     return;
   }
   bool connected = parse_json_bool(resp, "connected", false);
+  bool awaiting_plate_clear = parse_json_bool(resp, "awaiting_plate_clear", false);
   lock_state();
   display_state_.printer_connected = connected;
+  display_state_.awaiting_plate_clear = awaiting_plate_clear;
   unlock_state();
   ESP_LOGD(TAG, "Printer %s connected=%s", printer_id.c_str(), connected ? "true" : "false");
 }
@@ -3777,6 +3782,32 @@ void BambuddyAPIComponent::api_archive_spool(int spool_id) {
   } else {
     ESP_LOGW(TAG, "api_archive_spool %d: failed", spool_id);
     set_status("Archive failed");
+  }
+}
+
+void BambuddyAPIComponent::confirm_plate_cleared() {
+  lock_state();
+  std::string printer_id = display_state_.selected_printer_id;
+  display_state_.awaiting_plate_clear = false;  // optimistic — popup closes immediately
+  unlock_state();
+  if (printer_id.empty()) return;
+  HttpJob job;
+  job.kind = HttpJob::CLEAR_PLATE;
+  job.s1   = printer_id;
+  enqueue_job(job);
+}
+
+void BambuddyAPIComponent::api_clear_plate(const std::string &printer_id) {
+  if (printer_id.empty()) return;
+  std::string path = "/printers/" + printer_id + "/clear-plate";
+  std::string resp;
+  bool ok = http_post_api(path, "", resp);
+  if (ok) {
+    ESP_LOGI(TAG, "api_clear_plate %s: ok", printer_id.c_str());
+    set_status("Plate clear confirmed");
+  } else {
+    ESP_LOGW(TAG, "api_clear_plate %s: failed", printer_id.c_str());
+    set_status("Plate clear failed");
   }
 }
 

--- a/components/bambuddy_api/bambuddy_api.h
+++ b/components/bambuddy_api/bambuddy_api.h
@@ -316,15 +316,13 @@ class BambuddyAPIComponent : public Component {
   // Build-plate-clear confirmation popup (gated by a runtime settings toggle
   // in the YAML). confirm_plate_cleared() optimistically clears the local
   // flag and notifies the backend via POST /api/v1/printers/{id}/clear-plate.
-  // dismiss_plate_clear_popup() (the "Discard" button) only clears the local
-  // flag — the backend is not notified, so the popup can reappear on the next
-  // poll if the backend still reports awaiting_plate_clear.
+  // dismiss_plate_clear_popup() (the "Discard" button) does NOT touch
+  // awaiting_plate_clear — the backend is not notified, so its flag stays
+  // true until it's actually cleared some other way. The YAML-side
+  // plate_clear_dismissed global (not this flag) is what suppresses the
+  // popup from reappearing on the next poll while it's still true.
   void confirm_plate_cleared();
-  void dismiss_plate_clear_popup() {
-    lock_state();
-    display_state_.awaiting_plate_clear = false;
-    unlock_state();
-  }
+  void dismiss_plate_clear_popup() { set_status("Plate clear dismissed"); }
   void dismiss_archive_proposal() {
     lock_state();
     display_state_.propose_archive = false;

--- a/components/bambuddy_api/bambuddy_api.h
+++ b/components/bambuddy_api/bambuddy_api.h
@@ -177,6 +177,10 @@ struct DisplayState {
   int selected_printer_idx{0};
   std::string selected_printer_id;
   bool printer_connected{false};
+  // True when the backend reports the printer is waiting for the user to
+  // physically clear the build plate (awaiting_plate_clear on GET
+  // /api/v1/printers/{id}/status). Drives the almost-full-screen confirm popup.
+  bool awaiting_plate_clear{false};
 
 
   std::vector<AMSUnit> ams_units;
@@ -308,6 +312,19 @@ class BambuddyAPIComponent : public Component {
 
   // Archive a spool; dismiss_archive_proposal() cancels without action.
   void archive_spool(int spool_id);
+
+  // Build-plate-clear confirmation popup (gated by a runtime settings toggle
+  // in the YAML). confirm_plate_cleared() optimistically clears the local
+  // flag and notifies the backend via POST /api/v1/printers/{id}/clear-plate.
+  // dismiss_plate_clear_popup() (the "Discard" button) only clears the local
+  // flag — the backend is not notified, so the popup can reappear on the next
+  // poll if the backend still reports awaiting_plate_clear.
+  void confirm_plate_cleared();
+  void dismiss_plate_clear_popup() {
+    lock_state();
+    display_state_.awaiting_plate_clear = false;
+    unlock_state();
+  }
   void dismiss_archive_proposal() {
     lock_state();
     display_state_.propose_archive = false;
@@ -463,6 +480,7 @@ class BambuddyAPIComponent : public Component {
       UPDATE_CALIBRATION,      // POST /calibration/set-factor (reference + measured net)
       UPDATE_SPOOL_WEIGHT,     // PATCH /inventory/spools/{id} {"weight_used": X}
       ARCHIVE_SPOOL,           // POST /inventory/spools/{id}/archive
+      CLEAR_PLATE,             // POST /api/v1/printers/{id}/clear-plate
       // Scale push mode: scale → console (only processed when scale_mode_)
       SCALE_PUSH_WEIGHT,       // POST {console_url}/scale/weight
       SCALE_PUSH_NFC_SCANNED,  // POST {console_url}/scale/nfc/tag-scanned
@@ -626,6 +644,9 @@ class BambuddyAPIComponent : public Component {
                     const std::string &tray_uuid, const std::string &tag_type);
   void api_update_spool_weight(int spool_id, float remaining_g);
   void api_archive_spool(int spool_id);
+  // POST /api/v1/printers/{id}/clear-plate — notifies the backend the build
+  // plate has been physically cleared.
+  void api_clear_plate(const std::string &printer_id);
   // Create a minimal PLA spool linked to uid.
   // Internal: single POST /inventory/spools with tag_uid in the body.
   // Spoolman: POST /spoolman/inventory/spools has no tag field, so this does

--- a/espoolbuddy/spoolbuddy_app.yaml
+++ b/espoolbuddy/spoolbuddy_app.yaml
@@ -3,7 +3,7 @@
 # of the Settings screen (sourced from this value via ESPHOME_PROJECT_VERSION).
 esphome:
   project:
-    version: "0.22.15"
+    version: "0.23.0"
 
 
 # ============================================================================
@@ -62,6 +62,14 @@ globals:
     type: int
     restore_value: yes
     initial_value: '1'
+  - id: plate_clear_confirm_enabled  # 1 = show the build-plate-clear confirm popup, 0 = disabled
+    type: int
+    restore_value: yes
+    initial_value: '0'
+  - id: plate_clear_popup_open  # 1 while the plate-clear popup is on screen (guards re-showing it)
+    type: int
+    restore_value: no
+    initial_value: '0'
   - id: wifi_sleep_mode      # WiFi during sleep: 0=PowerSave(MAX_MODEM, stays online) 1=Off(appears offline)
     type: int
     restore_value: yes
@@ -154,11 +162,14 @@ script:
           // Sync settings toggles and sleep/brightness widgets with restored globals.
           id(update_nfc_sleep_btn).execute();
           id(update_sound_btn).execute();
+          id(update_plateclear_btn).execute();
           id(update_wifi_sleep_btn).execute();
           id(update_sleep_timeout_lbl).execute();
           id(update_backlight_brightness).execute();
-          // Close sleep subpage when switching away from settings
+          // Close the Settings subpages when switching away from settings
           lv_obj_add_flag(id(content_sleep), LV_OBJ_FLAG_HIDDEN);
+          lv_obj_add_flag(id(content_system), LV_OBJ_FLAG_HIDDEN);
+          lv_obj_add_flag(id(content_features), LV_OBJ_FLAG_HIDDEN);
 
   # Highlight the active segment of the Settings "NFC in sleep" Off/Slow/On row
   # from the nfc_sleep_mode global. Called on boot/tab-switch (apply_tab) and tap.
@@ -189,6 +200,22 @@ script:
           lv_obj_set_style_bg_color(id(btn_sound_on),
               on ? lv_color_hex(0x0F3460) : lv_color_hex(0x1B1B2A), LV_PART_MAIN);
           lv_obj_set_style_text_color(id(lbl_sound_on),
+              on ? lv_color_hex(0x4ECDC4) : lv_color_hex(0x8888AA), LV_PART_MAIN);
+
+  # Refresh the Settings "Confirm Plate Clear: Off/On" toggle from the
+  # plate_clear_confirm_enabled global. Called on boot/tab-switch (apply_tab)
+  # and on tap.
+  - id: update_plateclear_btn
+    then:
+      - lambda: |-
+          bool on = id(plate_clear_confirm_enabled);
+          lv_obj_set_style_bg_color(id(btn_plateclear_off),
+              !on ? lv_color_hex(0x0F3460) : lv_color_hex(0x1B1B2A), LV_PART_MAIN);
+          lv_obj_set_style_text_color(id(lbl_plateclear_off),
+              !on ? lv_color_hex(0x4ECDC4) : lv_color_hex(0x8888AA), LV_PART_MAIN);
+          lv_obj_set_style_bg_color(id(btn_plateclear_on),
+              on ? lv_color_hex(0x0F3460) : lv_color_hex(0x1B1B2A), LV_PART_MAIN);
+          lv_obj_set_style_text_color(id(lbl_plateclear_on),
               on ? lv_color_hex(0x4ECDC4) : lv_color_hex(0x8888AA), LV_PART_MAIN);
 
   # Refresh the Settings "WiFi in sleep" toggle from the wifi_sleep_mode global.
@@ -554,6 +581,21 @@ interval:
             // more. A wake resets inactivity, so the next tick falls through here
             // and renders again immediately.
             if (sleeping) return;
+          }
+
+          // ---- Build-plate-clear confirmation popup ----
+          // Gated by the "Confirm Plate Clear" settings toggle. Shown on top of
+          // whatever tab is active (like the wake guard) so it isn't tied to the
+          // NFC/AMS/Scale content switching. plate_clear_popup_open guards
+          // against re-showing every tick while it's already up.
+          if (s.awaiting_plate_clear && id(plate_clear_confirm_enabled)
+              && !id(plate_clear_popup_open)) {
+            id(plate_clear_popup_open) = 1;
+            lv_obj_clear_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
+          } else if (!s.awaiting_plate_clear && id(plate_clear_popup_open)) {
+            // Backend-side flag cleared (e.g. confirmed from elsewhere) — close it.
+            id(plate_clear_popup_open) = 0;
+            lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
           }
 
           // ---- Header icons ----

--- a/espoolbuddy/spoolbuddy_app.yaml
+++ b/espoolbuddy/spoolbuddy_app.yaml
@@ -70,6 +70,10 @@ globals:
     type: int
     restore_value: no
     initial_value: '0'
+  - id: plate_clear_dismissed  # 1 after "Discard" — suppresses the popup until the backend's
+    type: int                  # awaiting_plate_clear flag is next observed false (re-arms it)
+    restore_value: no
+    initial_value: '0'
   - id: wifi_sleep_mode      # WiFi during sleep: 0=PowerSave(MAX_MODEM, stays online) 1=Off(appears offline)
     type: int
     restore_value: yes
@@ -588,14 +592,31 @@ interval:
           // whatever tab is active (like the wake guard) so it isn't tied to the
           // NFC/AMS/Scale content switching. plate_clear_popup_open guards
           // against re-showing every tick while it's already up.
+          //
+          // plate_clear_dismissed: set by the popup's "Discard" button (which,
+          // unlike Confirm, does not notify the backend) so the still-true
+          // awaiting_plate_clear flag doesn't just pop the same popup back up
+          // on the next status poll. It's only cleared once awaiting_plate_clear
+          // is actually observed false (the plate-clear was resolved some other
+          // way, e.g. from the backend UI) — that re-arms the popup for the next
+          // time the flag transitions to true.
           if (s.awaiting_plate_clear && id(plate_clear_confirm_enabled)
-              && !id(plate_clear_popup_open)) {
+              && !id(plate_clear_popup_open) && !id(plate_clear_dismissed)) {
             id(plate_clear_popup_open) = 1;
             lv_obj_clear_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
-          } else if (!s.awaiting_plate_clear && id(plate_clear_popup_open)) {
-            // Backend-side flag cleared (e.g. confirmed from elsewhere) — close it.
-            id(plate_clear_popup_open) = 0;
-            lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
+            // A completed print usually triggers this popup — a short rising
+            // "success" chime on the same rising edge that opens it.
+            if (id(sound_enabled) && !id(rtttl_player)->is_playing())
+              id(rtttl_player)->play("success:d=8,o=6,b=180:c,e,g,c7");
+          } else if (!s.awaiting_plate_clear) {
+            // Backend-side flag cleared (confirmed here or from elsewhere) —
+            // close the popup if it's still open, and re-arm the discard
+            // suppression for the next time the flag goes true again.
+            if (id(plate_clear_popup_open)) {
+              id(plate_clear_popup_open) = 0;
+              lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
+            }
+            id(plate_clear_dismissed) = 0;
           }
 
           // ---- Header icons ----

--- a/espoolbuddy/spoolbuddy_assets.yaml
+++ b/espoolbuddy/spoolbuddy_assets.yaml
@@ -125,4 +125,9 @@ font:
       - "\U000F0396"   # nfc    (NFC tab)
       - "\U000F0493"   # cog    (Settings tab)
       - "\U000F003C"   # archive (empty-spool popup)
-
+  - file: "https://github.com/Templarian/MaterialDesign-Webfont/raw/master/fonts/materialdesignicons-webfont.ttf"
+    id: mdi_48
+    size: 48
+    bpp: 4
+    glyphs:
+      - "\U000F1276"   # magnify-scan (plate-clear confirm popup)

--- a/espoolbuddy/spoolbuddy_lvgl.yaml
+++ b/espoolbuddy/spoolbuddy_lvgl.yaml
@@ -1857,6 +1857,9 @@ lvgl:
                           then:
                             - lambda: |-
                                 id(plate_clear_popup_open) = 0;
+                                // Suppress the popup until awaiting_plate_clear is next observed
+                                // false — see the interval lambda in spoolbuddy_app.yaml.
+                                id(plate_clear_dismissed) = 1;
                                 lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
                                 bambuddy->dismiss_plate_clear_popup();
                         widgets:

--- a/espoolbuddy/spoolbuddy_lvgl.yaml
+++ b/espoolbuddy/spoolbuddy_lvgl.yaml
@@ -280,209 +280,58 @@ lvgl:
                         radius: 0
                         scrollbar_mode: "OFF"
 
-                    # ==== Settings rows (top-aligned): Printer | NFC in sleep | Sound ====
-                    # ---- Row: selected printer (tap the value to open the picker popup) ----
+                    # ==== Settings menu: two category rows opening full-page subpages ====
+                    # ---- Row: System (printer, brightness, sleep, reboot) ----
                     - obj:
                         x: 0
                         y: 36
                         width: 480
-                        height: 38
+                        height: 42
                         bg_opa: TRANSP
                         border_width: 0
                         pad_all: 0
                         scrollbar_mode: "OFF"
                         widgets:
-                          - label:
-                              x: 14
-                              width: 110
-                              text: "Printer"
-                              text_font: roboto_16
-                              text_color: 0xAAAAAA
-                              align: LEFT_MID
                           - button:
-                              id: btn_printer_pick
-                              x: 150
+                              id: btn_system_page
+                              x: 8
                               y: 3
-                              width: 320
-                              height: 32
+                              width: 464
+                              height: 36
                               styles: sty_card
                               scrollbar_mode: "OFF"
                               on_click:
                                 then:
-                                  - lambda: 'lv_obj_clear_flag(id(printer_modal), LV_OBJ_FLAG_HIDDEN);'
+                                  - lambda: 'lv_obj_clear_flag(id(content_system), LV_OBJ_FLAG_HIDDEN);'
                               widgets:
-                                - label: {id: lbl_printer_sel_icon, x: 8, width: 24, text: "\U000F0765", text_font: mdi_24, text_color: 0x666688, align: LEFT_MID}
-                                - label: {id: lbl_printer_sel, x: 38, width: 228, text: "—", text_font: roboto_16, text_color: 0xDDDDEE, long_mode: DOT, align: LEFT_MID}
-                                - label: {x: 296, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
+                                - label: {x: 16, width: 400, text: "System", text_font: roboto_16, text_color: 0xDDDDEE, align: LEFT_MID}
+                                - label: {x: 424, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
 
-                    # ---- Row: Sound on/off (Off | On segments) ----
+                    # ---- Row: Features (sound, plate-clear confirm) ----
                     - obj:
                         x: 0
-                        y: 78
+                        y: 82
                         width: 480
-                        height: 38
+                        height: 42
                         bg_opa: TRANSP
                         border_width: 0
                         pad_all: 0
                         scrollbar_mode: "OFF"
                         widgets:
-                          - label:
-                              x: 14
-                              width: 130
-                              text: "Sound"
-                              text_font: roboto_16
-                              text_color: 0xAAAAAA
-                              align: LEFT_MID
                           - button:
-                              id: btn_sound_off
-                              x: 150
+                              id: btn_features_page
+                              x: 8
                               y: 3
-                              width: 158
-                              height: 32
+                              width: 464
+                              height: 36
                               styles: sty_card
                               scrollbar_mode: "OFF"
                               on_click:
                                 then:
-                                  - lambda: 'id(sound_enabled) = 0;'
-                                  - script.execute: update_sound_btn
+                                  - lambda: 'lv_obj_clear_flag(id(content_features), LV_OBJ_FLAG_HIDDEN);'
                               widgets:
-                                - label: {id: lbl_sound_off, text: "Off", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
-                          - button:
-                              id: btn_sound_on
-                              x: 312
-                              y: 3
-                              width: 158
-                              height: 32
-                              styles: sty_card
-                              scrollbar_mode: "OFF"
-                              on_click:
-                                then:
-                                  - lambda: 'id(sound_enabled) = 1;'
-                                  - script.execute: update_sound_btn
-                              widgets:
-                                - label: {id: lbl_sound_on, text: "On", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
-
-                    # ---- Row: Backlight brightness (slider 25–100%, 5% steps) ----
-                    - obj:
-                        x: 0
-                        y: 120
-                        width: 480
-                        height: 38
-                        bg_opa: TRANSP
-                        border_width: 0
-                        pad_all: 0
-                        scrollbar_mode: "OFF"
-                        widgets:
-                          - label:
-                              x: 14
-                              width: 130
-                              text: "Brightness"
-                              text_font: roboto_16
-                              text_color: 0xAAAAAA
-                              align: LEFT_MID
-                          - slider:
-                              id: sl_brightness
-                              x: 148
-                              y: 11
-                              width: 274
-                              height: 16
-                              min_value: 25
-                              max_value: 100
-                              value: 100
-                              on_value:
-                                then:
-                                  - lambda: |-
-                                      // Snap to 5% steps and store. Inline to avoid circular
-                                      // trigger: update_backlight_brightness → lv_slider_set_value
-                                      // → on_value → update_backlight_brightness → ...
-                                      int snapped = ((x + 2) / 5) * 5;
-                                      if (snapped < 25) snapped = 25;
-                                      if (snapped > 100) snapped = 100;
-                                      id(backlight_brightness_pct) = snapped;
-                                      id(display_backlight).turn_on()
-                                        .set_brightness(snapped / 100.0f)
-                                        .set_transition_length(50).perform();
-                                      char buf[6];
-                                      snprintf(buf, sizeof(buf), "%d%%", snapped);
-                                      lv_label_set_text(id(lbl_brightness_val), buf);
-                          - label:
-                              id: lbl_brightness_val
-                              x: 430
-                              width: 46
-                              text: "100%"
-                              text_font: roboto_16
-                              text_color: 0xDDDDEE
-                              text_align: RIGHT
-                              align: LEFT_MID
-
-                    # ---- Row: Sleep settings (opens sleep subpage) ----
-                    - obj:
-                        x: 0
-                        y: 162
-                        width: 480
-                        height: 38
-                        bg_opa: TRANSP
-                        border_width: 0
-                        pad_all: 0
-                        scrollbar_mode: "OFF"
-                        widgets:
-                          - label:
-                              x: 14
-                              width: 110
-                              text: "Sleep"
-                              text_font: roboto_16
-                              text_color: 0xAAAAAA
-                              align: LEFT_MID
-                          - button:
-                              id: btn_sleep_page
-                              x: 150
-                              y: 3
-                              width: 320
-                              height: 32
-                              styles: sty_card
-                              scrollbar_mode: "OFF"
-                              on_click:
-                                then:
-                                  - lambda: 'lv_obj_clear_flag(id(content_sleep), LV_OBJ_FLAG_HIDDEN);'
-                              widgets:
-                                - label: {x: 8, width: 280, text: "Sleep settings", text_font: roboto_16, text_color: 0xDDDDEE, align: LEFT_MID}
-                                - label: {x: 296, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
-
-                    # ---- Row: System (reboot — confirms via confirm_modal) ----
-                    - obj:
-                        x: 0
-                        y: 204
-                        width: 480
-                        height: 38
-                        bg_opa: TRANSP
-                        border_width: 0
-                        pad_all: 0
-                        scrollbar_mode: "OFF"
-                        widgets:
-                          - label:
-                              x: 14
-                              width: 110
-                              text: "System"
-                              text_font: roboto_16
-                              text_color: 0xAAAAAA
-                              align: LEFT_MID
-                          - button:
-                              id: btn_reboot
-                              x: 150
-                              y: 3
-                              width: 320
-                              height: 32
-                              styles: sty_card
-                              scrollbar_mode: "OFF"
-                              on_click:
-                                then:
-                                  - lambda: |-
-                                      id(confirm_action) = 3;
-                                      lv_label_set_text(id(confirm_msg), "Reboot the console now?");
-                                      lv_label_set_text(id(confirm_ok_lbl), "Reboot");
-                                      lv_obj_clear_flag(id(confirm_modal), LV_OBJ_FLAG_HIDDEN);
-                              widgets:
-                                - label: {text: "Reboot", text_font: roboto_16, text_color: 0xFF8888, align: CENTER}
+                                - label: {x: 16, width: 400, text: "Features", text_font: roboto_16, text_color: 0xDDDDEE, align: LEFT_MID}
+                                - label: {x: 424, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
 
                     # ---- App version (bottom-right; text set in apply_tab from
                     #      esphome.project.version via ESPHOME_PROJECT_VERSION) ----
@@ -495,7 +344,379 @@ lvgl:
                         y: 6
                         align: TOP_LEFT
 
-                    # ---- Sleep settings subpage (overlays full content_cfg area) ----
+                    # ---- System subpage (overlays full content_cfg area) ----
+                    # Printer | Brightness | Sleep (opens the nested content_sleep
+                    # subpage) | Reboot (confirms via confirm_modal).
+                    - obj:
+                        id: content_system
+                        x: 0
+                        y: 0
+                        width: 480
+                        height: 250
+                        bg_color: 0x12121A
+                        bg_opa: COVER
+                        border_width: 0
+                        radius: 0
+                        pad_all: 0
+                        scrollbar_mode: "OFF"
+                        hidden: true
+                        widgets:
+                          # Header with back button
+                          - obj:
+                              x: 0
+                              y: 0
+                              width: 480
+                              height: 28
+                              styles: sty_bar
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - button:
+                                    x: 0
+                                    y: 0
+                                    width: 40
+                                    height: 28
+                                    bg_opa: TRANSP
+                                    border_width: 0
+                                    radius: 0
+                                    pad_all: 0
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'lv_obj_add_flag(id(content_system), LV_OBJ_FLAG_HIDDEN);'
+                                    widgets:
+                                      - label: {text: "\U000F0141", text_font: mdi_24, text_color: 0x7B9EFF, align: CENTER}
+                                - label:
+                                    x: 0
+                                    width: 480
+                                    text: "System"
+                                    text_font: roboto_20
+                                    text_color: 0x7B9EFF
+                                    text_align: CENTER
+                                    align: CENTER
+                          # Separator
+                          - obj:
+                              x: 0
+                              y: 28
+                              width: 480
+                              height: 1
+                              bg_color: 0x454572
+                              bg_opa: COVER
+                              border_width: 0
+                              radius: 0
+                              scrollbar_mode: "OFF"
+
+                          # ---- Row: selected printer (tap the value to open the picker popup) ----
+                          - obj:
+                              x: 0
+                              y: 36
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 110
+                                    text: "Printer"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - button:
+                                    id: btn_printer_pick
+                                    x: 150
+                                    y: 3
+                                    width: 320
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'lv_obj_clear_flag(id(printer_modal), LV_OBJ_FLAG_HIDDEN);'
+                                    widgets:
+                                      - label: {id: lbl_printer_sel_icon, x: 8, width: 24, text: "\U000F0765", text_font: mdi_24, text_color: 0x666688, align: LEFT_MID}
+                                      - label: {id: lbl_printer_sel, x: 38, width: 228, text: "—", text_font: roboto_16, text_color: 0xDDDDEE, long_mode: DOT, align: LEFT_MID}
+                                      - label: {x: 296, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
+
+                          # ---- Row: Backlight brightness (slider 25–100%, 5% steps) ----
+                          - obj:
+                              x: 0
+                              y: 78
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 130
+                                    text: "Brightness"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - slider:
+                                    id: sl_brightness
+                                    x: 148
+                                    y: 11
+                                    width: 274
+                                    height: 16
+                                    min_value: 25
+                                    max_value: 100
+                                    value: 100
+                                    on_value:
+                                      then:
+                                        - lambda: |-
+                                            // Snap to 5% steps and store. Inline to avoid circular
+                                            // trigger: update_backlight_brightness → lv_slider_set_value
+                                            // → on_value → update_backlight_brightness → ...
+                                            int snapped = ((x + 2) / 5) * 5;
+                                            if (snapped < 25) snapped = 25;
+                                            if (snapped > 100) snapped = 100;
+                                            id(backlight_brightness_pct) = snapped;
+                                            id(display_backlight).turn_on()
+                                              .set_brightness(snapped / 100.0f)
+                                              .set_transition_length(50).perform();
+                                            char buf[6];
+                                            snprintf(buf, sizeof(buf), "%d%%", snapped);
+                                            lv_label_set_text(id(lbl_brightness_val), buf);
+                                - label:
+                                    id: lbl_brightness_val
+                                    x: 430
+                                    width: 46
+                                    text: "100%"
+                                    text_font: roboto_16
+                                    text_color: 0xDDDDEE
+                                    text_align: RIGHT
+                                    align: LEFT_MID
+
+                          # ---- Row: Sleep settings (opens the nested sleep subpage) ----
+                          - obj:
+                              x: 0
+                              y: 120
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 110
+                                    text: "Sleep"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - button:
+                                    id: btn_sleep_page
+                                    x: 150
+                                    y: 3
+                                    width: 320
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'lv_obj_clear_flag(id(content_sleep), LV_OBJ_FLAG_HIDDEN);'
+                                    widgets:
+                                      - label: {x: 8, width: 280, text: "Sleep settings", text_font: roboto_16, text_color: 0xDDDDEE, align: LEFT_MID}
+                                      - label: {x: 296, width: 24, text: "\U000F0142", text_font: mdi_24, text_color: 0x7B9EFF, align: LEFT_MID}
+
+                          # ---- Row: Reboot (confirms via confirm_modal) ----
+                          - obj:
+                              x: 0
+                              y: 162
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 110
+                                    text: "Reboot"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - button:
+                                    id: btn_reboot
+                                    x: 150
+                                    y: 3
+                                    width: 320
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: |-
+                                            id(confirm_action) = 3;
+                                            lv_label_set_text(id(confirm_msg), "Reboot the console now?");
+                                            lv_label_set_text(id(confirm_ok_lbl), "Reboot");
+                                            lv_obj_clear_flag(id(confirm_modal), LV_OBJ_FLAG_HIDDEN);
+                                    widgets:
+                                      - label: {text: "Reboot", text_font: roboto_16, text_color: 0xFF8888, align: CENTER}
+
+                    # ---- Features subpage (overlays full content_cfg area) ----
+                    # Sound | Plate Clear confirmation toggle.
+                    - obj:
+                        id: content_features
+                        x: 0
+                        y: 0
+                        width: 480
+                        height: 250
+                        bg_color: 0x12121A
+                        bg_opa: COVER
+                        border_width: 0
+                        radius: 0
+                        pad_all: 0
+                        scrollbar_mode: "OFF"
+                        hidden: true
+                        widgets:
+                          # Header with back button
+                          - obj:
+                              x: 0
+                              y: 0
+                              width: 480
+                              height: 28
+                              styles: sty_bar
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - button:
+                                    x: 0
+                                    y: 0
+                                    width: 40
+                                    height: 28
+                                    bg_opa: TRANSP
+                                    border_width: 0
+                                    radius: 0
+                                    pad_all: 0
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'lv_obj_add_flag(id(content_features), LV_OBJ_FLAG_HIDDEN);'
+                                    widgets:
+                                      - label: {text: "\U000F0141", text_font: mdi_24, text_color: 0x7B9EFF, align: CENTER}
+                                - label:
+                                    x: 0
+                                    width: 480
+                                    text: "Features"
+                                    text_font: roboto_20
+                                    text_color: 0x7B9EFF
+                                    text_align: CENTER
+                                    align: CENTER
+                          # Separator
+                          - obj:
+                              x: 0
+                              y: 28
+                              width: 480
+                              height: 1
+                              bg_color: 0x454572
+                              bg_opa: COVER
+                              border_width: 0
+                              radius: 0
+                              scrollbar_mode: "OFF"
+
+                          # ---- Row: Sound on/off (Off | On segments) ----
+                          - obj:
+                              x: 0
+                              y: 36
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 130
+                                    text: "Sound"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - button:
+                                    id: btn_sound_off
+                                    x: 150
+                                    y: 3
+                                    width: 158
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'id(sound_enabled) = 0;'
+                                        - script.execute: update_sound_btn
+                                    widgets:
+                                      - label: {id: lbl_sound_off, text: "Off", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
+                                - button:
+                                    id: btn_sound_on
+                                    x: 312
+                                    y: 3
+                                    width: 158
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'id(sound_enabled) = 1;'
+                                        - script.execute: update_sound_btn
+                                    widgets:
+                                      - label: {id: lbl_sound_on, text: "On", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
+
+                          # ---- Row: Confirm Plate Clear on/off (Off | On segments) ----
+                          - obj:
+                              x: 0
+                              y: 78
+                              width: 480
+                              height: 38
+                              bg_opa: TRANSP
+                              border_width: 0
+                              pad_all: 0
+                              scrollbar_mode: "OFF"
+                              widgets:
+                                - label:
+                                    x: 14
+                                    width: 130
+                                    text: "Plate Clear"
+                                    text_font: roboto_16
+                                    text_color: 0xAAAAAA
+                                    align: LEFT_MID
+                                - button:
+                                    id: btn_plateclear_off
+                                    x: 150
+                                    y: 3
+                                    width: 158
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'id(plate_clear_confirm_enabled) = 0;'
+                                        - script.execute: update_plateclear_btn
+                                    widgets:
+                                      - label: {id: lbl_plateclear_off, text: "Off", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
+                                - button:
+                                    id: btn_plateclear_on
+                                    x: 312
+                                    y: 3
+                                    width: 158
+                                    height: 32
+                                    styles: sty_card
+                                    scrollbar_mode: "OFF"
+                                    on_click:
+                                      then:
+                                        - lambda: 'id(plate_clear_confirm_enabled) = 1;'
+                                        - script.execute: update_plateclear_btn
+                                    widgets:
+                                      - label: {id: lbl_plateclear_on, text: "On", text_font: roboto_16, text_color: 0x8888AA, align: CENTER}
+
+                    # ---- Sleep settings subpage (nested — opened from within
+                    #      content_system; overlays the full content_cfg area) ----
                     - obj:
                         id: content_sleep
                         x: 0
@@ -1555,6 +1776,110 @@ lvgl:
                             - lambda: "lv_obj_add_flag(id(assign_id_modal), LV_OBJ_FLAG_HIDDEN);"
                         widgets:
                           - label: {text: "Cancel", text_font: roboto_16, text_color: 0xDDDDEE, align: CENTER}
+
+              # ================ PLATE CLEAR POPUP =============================
+              # Almost-full-screen confirmation shown when the backend reports
+              # awaiting_plate_clear (gated by the "Plate Clear" settings toggle;
+              # see plate_clear_confirm_enabled / update_plateclear_btn and the
+              # show/hide logic in the interval lambda). Confirm notifies the
+              # backend via bambuddy->confirm_plate_cleared(); Discard just
+              # closes the popup locally without notifying the backend.
+              - obj:
+                  id: plate_clear_popup
+                  x: 20
+                  y: 20
+                  width: 440
+                  height: 280
+                  bg_color: 0x1B5E20
+                  bg_opa: COVER
+                  border_color: 0x4CAF50
+                  border_width: 3
+                  border_opa: COVER
+                  radius: 16
+                  pad_all: 0
+                  scrollbar_mode: "OFF"
+                  shadow_width: 20
+                  shadow_offset_x: 0
+                  shadow_offset_y: 8
+                  shadow_spread: 2
+                  shadow_color: 0x000000
+                  shadow_opa: COVER
+                  hidden: true
+                  widgets:
+                    # align: TOP_MID treats x/y as an offset from the centred
+                    # anchor point, not an absolute coordinate — combined with
+                    # a nonzero x that silently shifts the "centred" text off
+                    # centre. Use TOP_LEFT (absolute x) with a width/x pair
+                    # that's symmetric within the 440px popup instead, and let
+                    # text_align: CENTER centre the text inside that box.
+                    - label:
+                        x: 16
+                        y: 30
+                        width: 408
+                        height: 48
+                        text: "\U000F1276"
+                        text_font: mdi_48
+                        text_color: 0xFFFFFF
+                        text_align: CENTER
+                        align: TOP_LEFT
+                    - label:
+                        x: 16
+                        y: 96
+                        width: 408
+                        text: "Build Plate Clear"
+                        text_font: roboto_28
+                        text_color: 0xFFFFFF
+                        text_align: CENTER
+                        align: TOP_LEFT
+                    - label:
+                        x: 32
+                        y: 158
+                        width: 376
+                        height: 56
+                        text: "Please confirm that the build plate has been cleared."
+                        text_font: roboto_16
+                        text_color: 0xE8F5E9
+                        text_align: CENTER
+                        long_mode: WRAP
+                        align: TOP_LEFT
+                    - button:
+                        id: btn_plateclear_discard
+                        x: 20
+                        y: 228
+                        width: 190
+                        height: 40
+                        bg_color: 0x0F3D14
+                        border_color: 0xA5D6A7
+                        border_width: 2
+                        radius: 6
+                        scrollbar_mode: "OFF"
+                        on_click:
+                          then:
+                            - lambda: |-
+                                id(plate_clear_popup_open) = 0;
+                                lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
+                                bambuddy->dismiss_plate_clear_popup();
+                        widgets:
+                          - label: {text: "Discard", text_font: roboto_16, text_color: 0xE8F5E9, align: CENTER}
+                    - button:
+                        id: btn_plateclear_confirm
+                        x: 230
+                        y: 228
+                        width: 190
+                        height: 40
+                        bg_color: 0xFFFFFF
+                        border_color: 0xFFFFFF
+                        border_width: 2
+                        radius: 6
+                        scrollbar_mode: "OFF"
+                        on_click:
+                          then:
+                            - lambda: |-
+                                id(plate_clear_popup_open) = 0;
+                                lv_obj_add_flag(id(plate_clear_popup), LV_OBJ_FLAG_HIDDEN);
+                                bambuddy->confirm_plate_cleared();
+                        widgets:
+                          - label: {text: "Confirm", text_font: roboto_16, text_color: 0x1B5E20, align: CENTER}
 
               # ================ WAKE GUARD ====================================
               # Full-screen transparent overlay that sits on top of all other


### PR DESCRIPTION
Add a setting to enable/disable notification for clearing the plate after a print has been completed.

If confirmed, Bambuddy is notified about the plate cleared, if discarded no further action is taken and the popup won't appear again for the same print. 
A chime is played if sound is enabled. 

<img width="938" height="738" alt="20260809_114910" src="https://github.com/user-attachments/assets/969e1e27-6ac1-4690-af40-48185ef6a0e9" />

Closes #2 