### PR TITLE
Retry stale connections and add threshold for failed backend connection

### DIFF
--- a/components/bambuddy_api/__init__.py
+++ b/components/bambuddy_api/__init__.py
@@ -28,6 +28,7 @@ CONF_API_KEY = "api_key"
 CONF_DEVICE_ID = "device_id"
 CONF_HOSTNAME = "hostname"
 CONF_HEARTBEAT_INTERVAL = "heartbeat_interval"
+CONF_HEARTBEAT_FAIL_THRESHOLD = "heartbeat_fail_threshold"
 CONF_SCALE_REPORT_INTERVAL = "scale_report_interval"
 CONF_PRINTER_POLL_INTERVAL = "printer_poll_interval"
 CONF_SCALE_MODE = "scale_mode"
@@ -71,6 +72,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DEVICE_ID, default=""): cv.string,
             cv.Optional(CONF_HOSTNAME, default="SpoolBuddy-ESP"): cv.string,
             cv.Optional(CONF_HEARTBEAT_INTERVAL, default=10): cv.positive_int,
+            # Consecutive failed heartbeat POSTs required before the backend is
+            # actually marked down (console cloud/WiFi icons turn red). Debounces
+            # transient network blips — a single successful heartbeat always
+            # clears this immediately, so recovery is never delayed.
+            cv.Optional(CONF_HEARTBEAT_FAIL_THRESHOLD, default=3): cv.positive_int,
             cv.Optional(CONF_SCALE_REPORT_INTERVAL, default=1000): cv.positive_int,
             cv.Optional(CONF_PRINTER_POLL_INTERVAL, default=30): cv.positive_int,
             # Scale mode: this device IS the scale — starts a local HTTP server for
@@ -117,6 +123,7 @@ async def to_code(config):
     cg.add(var.set_device_id(config[CONF_DEVICE_ID]))
     cg.add(var.set_hostname(config[CONF_HOSTNAME]))
     cg.add(var.set_heartbeat_interval(config[CONF_HEARTBEAT_INTERVAL]))
+    cg.add(var.set_heartbeat_fail_threshold(config[CONF_HEARTBEAT_FAIL_THRESHOLD]))
     cg.add(var.set_scale_report_interval(config[CONF_SCALE_REPORT_INTERVAL]))
     cg.add(var.set_printer_poll_interval(config[CONF_PRINTER_POLL_INTERVAL]))
     cg.add(var.set_scale_mode(config[CONF_SCALE_MODE]))

--- a/components/bambuddy_api/bambuddy_api.cpp
+++ b/components/bambuddy_api/bambuddy_api.cpp
@@ -977,6 +977,12 @@ void BambuddyAPIComponent::api_heartbeat() {
   std::string resp;
   bool ok = http_post("/devices/" + device_id_ + "/heartbeat", js.str(), resp);
   if (!ok) {
+    heartbeat_fail_count_++;
+    if (heartbeat_fail_count_ < heartbeat_fail_threshold_) {
+      ESP_LOGD(TAG, "Heartbeat failed (%u/%u consecutive) — not yet marking backend down",
+               heartbeat_fail_count_, heartbeat_fail_threshold_);
+      return;
+    }
     lock_state();
     display_state_.backend_state = BackendState::ERROR;
     display_state_.status_message = "Lost connection to Bambuddy";
@@ -984,6 +990,7 @@ void BambuddyAPIComponent::api_heartbeat() {
     return;
   }
 
+  heartbeat_fail_count_ = 0;
   lock_state();
   display_state_.backend_state = BackendState::REGISTERED;
   // No reader configured means nothing will ever call set_nfc_ok(true), so
@@ -1628,6 +1635,17 @@ static const char *method_name(esp_http_client_method_t m) {
 //   with_api_key: add the X-API-Key header (backend requests only).
 //   quiet:        log failures at DEBUG instead of WARN — for the routine
 //                 scale→console pushes that fail whenever the console is off.
+//
+// A reused persistent backend connection (see is_backend below) can have been
+// silently closed by the server's idle/keep-alive timeout between calls —
+// e.g. an ASGI server's --timeout-keep-alive shorter than our heartbeat
+// interval closes it server-side while esp_http_client still thinks it's
+// open, so the next write into it fails even though the backend is perfectly
+// reachable. When a request fails on a connection we didn't just create in
+// this same call, retry once on a fresh connection before giving up, so a
+// mismatched server keep-alive timeout never surfaces as a failed heartbeat.
+// A failure on an already-fresh connection is a real connectivity problem
+// and is not retried.
 bool BambuddyAPIComponent::http_request(esp_http_client_method_t method,
                                          const std::string &url,
                                          const std::string &json_body,
@@ -1635,110 +1653,122 @@ bool BambuddyAPIComponent::http_request(esp_http_client_method_t method,
                                          int timeout_ms, bool with_api_key,
                                          bool quiet) {
   const char *m = method_name(method);
-  HttpContext ctx;
 
   // All requests rooted at backend_url_ share a persistent TLS connection so
   // the full mbedTLS cert-chain handshake happens once on first connect (or
   // after a dropped connection) rather than on every call.  Direct scale-push
   // calls (http_post_direct) go to a different host and keep per-call cleanup.
   bool is_backend = !backend_url_.empty() && url.rfind(backend_url_, 0) == 0;
-  esp_http_client_handle_t client;
+  bool reused_connection = is_backend && http_client_ != nullptr;
 
-  if (is_backend) {
-    if (!http_client_) {
+  for (int attempt = 0; attempt < 2; attempt++) {
+    HttpContext ctx;
+    esp_http_client_handle_t client;
+
+    if (is_backend) {
+      if (!http_client_) {
+        esp_http_client_config_t cfg = {};
+        cfg.url                   = url.c_str();
+        cfg.event_handler         = http_event_handler;
+        cfg.user_data             = nullptr;   // set per-call via set_user_data below
+        cfg.timeout_ms            = timeout_ms;
+        cfg.disable_auto_redirect = false;
+        cfg.crt_bundle_attach     = esp_crt_bundle_attach;
+        cfg.transport_type        = HTTP_TRANSPORT_UNKNOWN;
+        cfg.keep_alive_enable     = true;
+        http_client_ = esp_http_client_init(&cfg);
+        if (!http_client_) {
+          ESP_LOGE(TAG, "HTTP client init failed for %s %s", m, url.c_str());
+          return false;
+        }
+        ESP_LOGD(TAG, "Created persistent backend HTTP client");
+      }
+      client = http_client_;
+      esp_http_client_set_url(client, url.c_str());
+      esp_http_client_set_method(client, method);
+      esp_http_client_set_user_data(client, &ctx);
+      if (!json_body.empty()) {
+        esp_http_client_set_header(client, "Content-Type", "application/json");
+        esp_http_client_set_post_field(client, json_body.c_str(), (int)json_body.size());
+      } else {
+        esp_http_client_delete_header(client, "Content-Type");
+        esp_http_client_set_post_field(client, nullptr, 0);
+      }
+      if (with_api_key && !api_key_.empty())
+        esp_http_client_set_header(client, "X-API-Key", api_key_.c_str());
+      else
+        esp_http_client_delete_header(client, "X-API-Key");
+    } else {
       esp_http_client_config_t cfg = {};
       cfg.url                   = url.c_str();
+      cfg.method                = method;
       cfg.event_handler         = http_event_handler;
-      cfg.user_data             = nullptr;   // set per-call via set_user_data below
+      cfg.user_data             = &ctx;
       cfg.timeout_ms            = timeout_ms;
       cfg.disable_auto_redirect = false;
       cfg.crt_bundle_attach     = esp_crt_bundle_attach;
       cfg.transport_type        = HTTP_TRANSPORT_UNKNOWN;
-      cfg.keep_alive_enable     = true;
-      http_client_ = esp_http_client_init(&cfg);
-      if (!http_client_) {
+      client = esp_http_client_init(&cfg);
+      if (!client) {
         ESP_LOGE(TAG, "HTTP client init failed for %s %s", m, url.c_str());
         return false;
       }
-      ESP_LOGD(TAG, "Created persistent backend HTTP client");
+      if (!json_body.empty()) {
+        esp_http_client_set_header(client, "Content-Type", "application/json");
+        esp_http_client_set_post_field(client, json_body.c_str(), (int)json_body.size());
+      }
+      if (with_api_key && !api_key_.empty())
+        esp_http_client_set_header(client, "X-API-Key", api_key_.c_str());
     }
-    client = http_client_;
-    esp_http_client_set_url(client, url.c_str());
-    esp_http_client_set_method(client, method);
-    esp_http_client_set_user_data(client, &ctx);
+
+    ESP_LOGD(TAG, "--> %s %s", m, url.c_str());
     if (!json_body.empty()) {
-      esp_http_client_set_header(client, "Content-Type", "application/json");
-      esp_http_client_set_post_field(client, json_body.c_str(), (int)json_body.size());
-    } else {
-      esp_http_client_delete_header(client, "Content-Type");
-      esp_http_client_set_post_field(client, nullptr, 0);
+      ESP_LOGD(TAG, "    body: %s", json_body.c_str());
     }
-    if (with_api_key && !api_key_.empty())
-      esp_http_client_set_header(client, "X-API-Key", api_key_.c_str());
-    else
-      esp_http_client_delete_header(client, "X-API-Key");
-  } else {
-    esp_http_client_config_t cfg = {};
-    cfg.url                   = url.c_str();
-    cfg.method                = method;
-    cfg.event_handler         = http_event_handler;
-    cfg.user_data             = &ctx;
-    cfg.timeout_ms            = timeout_ms;
-    cfg.disable_auto_redirect = false;
-    cfg.crt_bundle_attach     = esp_crt_bundle_attach;
-    cfg.transport_type        = HTTP_TRANSPORT_UNKNOWN;
-    client = esp_http_client_init(&cfg);
-    if (!client) {
-      ESP_LOGE(TAG, "HTTP client init failed for %s %s", m, url.c_str());
+
+    // Feed the task WDT immediately before the blocking HTTP call.
+    arch_feed_wdt();
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+
+    if (!is_backend) {
+      esp_http_client_cleanup(client);
+    } else if (err != ESP_OK) {
+      // Connection broke — destroy so the retry below (or the next call, if
+      // we've already retried) reconnects fresh.
+      esp_http_client_cleanup(http_client_);
+      http_client_ = nullptr;
+    }
+
+    if (err != ESP_OK) {
+      if (reused_connection) {
+        ESP_LOGD(TAG, "%s %s failed on a reused connection (%s) — retrying fresh",
+                 m, url.c_str(), esp_err_to_name(err));
+        reused_connection = false;  // at most one retry
+        continue;
+      }
+      if (quiet)
+        ESP_LOGD(TAG, "<-- %s %s failed: %s", m, url.c_str(), esp_err_to_name(err));
+      else
+        ESP_LOGW(TAG, "<-- %s %s failed: %s", m, url.c_str(), esp_err_to_name(err));
       return false;
     }
-    if (!json_body.empty()) {
-      esp_http_client_set_header(client, "Content-Type", "application/json");
-      esp_http_client_set_post_field(client, json_body.c_str(), (int)json_body.size());
+    ESP_LOGD(TAG, "<-- %d %s %s", status, m, url.c_str());
+    ESP_LOGD(TAG, "    resp: %s", ctx.body.c_str());
+    if (status < 200 || status >= 300) {
+      if (quiet)
+        ESP_LOGD(TAG, "%s %s returned %d", m, url.c_str(), status);
+      else
+        ESP_LOGW(TAG, "HTTP %s %s returned %d", m, url.c_str(), status);
+      return false;
     }
-    if (with_api_key && !api_key_.empty())
-      esp_http_client_set_header(client, "X-API-Key", api_key_.c_str());
+    // Move (not copy) the accumulated body out: a large inventory response would
+    // otherwise need a second full-size allocation here, which can exhaust the
+    // internal heap and abort (exceptions are compiled out on ESP-IDF).
+    response_body = std::move(ctx.body);
+    return true;
   }
-
-  ESP_LOGD(TAG, "--> %s %s", m, url.c_str());
-  if (!json_body.empty()) {
-    ESP_LOGD(TAG, "    body: %s", json_body.c_str());
-  }
-
-  // Feed the task WDT immediately before the blocking HTTP call.
-  arch_feed_wdt();
-  esp_err_t err = esp_http_client_perform(client);
-  int status = esp_http_client_get_status_code(client);
-
-  if (!is_backend) {
-    esp_http_client_cleanup(client);
-  } else if (err != ESP_OK) {
-    // Connection broke — destroy so the next call reconnects fresh.
-    esp_http_client_cleanup(http_client_);
-    http_client_ = nullptr;
-  }
-
-  if (err != ESP_OK) {
-    if (quiet)
-      ESP_LOGD(TAG, "<-- %s %s failed: %s", m, url.c_str(), esp_err_to_name(err));
-    else
-      ESP_LOGW(TAG, "<-- %s %s failed: %s", m, url.c_str(), esp_err_to_name(err));
-    return false;
-  }
-  ESP_LOGD(TAG, "<-- %d %s %s", status, m, url.c_str());
-  ESP_LOGD(TAG, "    resp: %s", ctx.body.c_str());
-  if (status < 200 || status >= 300) {
-    if (quiet)
-      ESP_LOGD(TAG, "%s %s returned %d", m, url.c_str(), status);
-    else
-      ESP_LOGW(TAG, "HTTP %s %s returned %d", m, url.c_str(), status);
-    return false;
-  }
-  // Move (not copy) the accumulated body out: a large inventory response would
-  // otherwise need a second full-size allocation here, which can exhaust the
-  // internal heap and abort (exceptions are compiled out on ESP-IDF).
-  response_body = std::move(ctx.body);
-  return true;
+  return false;  // unreachable: every loop path returns or continues
 }
 
 std::string BambuddyAPIComponent::backend_url_for(const char *prefix,

--- a/components/bambuddy_api/bambuddy_api.h
+++ b/components/bambuddy_api/bambuddy_api.h
@@ -306,6 +306,7 @@ class BambuddyAPIComponent : public Component {
   void set_device_id(const std::string &id) { device_id_ = id; }
   void set_hostname(const std::string &hostname) { hostname_ = hostname; }
   void set_heartbeat_interval(uint32_t ms) { heartbeat_interval_ms_ = ms * 1000; }
+  void set_heartbeat_fail_threshold(uint8_t n) { heartbeat_fail_threshold_ = n; }
   void set_scale_report_interval(uint32_t ms) { scale_report_interval_ms_ = ms; }
   void set_printer_poll_interval(uint32_t s) { printer_poll_interval_ms_ = s * 1000; }
   // Scale server mode: this device IS the scale — serves weight/tare/calibrate
@@ -821,6 +822,12 @@ class BambuddyAPIComponent : public Component {
   uint32_t last_heartbeat_ms_{0};
   uint32_t last_register_ms_{0};
   uint32_t last_scale_report_ms_{0};
+  // Debounces backend_state ERROR: only mark the backend down after this many
+  // *consecutive* failed heartbeats, so a single transient blip doesn't flash
+  // the console's cloud/WiFi icons red. A single success always clears this
+  // immediately — recovery is not debounced, only the transition to "down".
+  uint8_t heartbeat_fail_count_{0};
+  uint8_t heartbeat_fail_threshold_{3};
 
   // Printer / AMS polling
   uint32_t printer_poll_interval_ms_{30000};

--- a/espoolbuddy/version.yaml
+++ b/espoolbuddy/version.yaml
@@ -5,7 +5,7 @@
 # entry-point YAML so there is exactly one number to update.
 esphome:
   project:
-    version: "0.24.0"
+    version: "0.24.1"
 
 # Reports the same version to Home Assistant (via the native api: component,
 # already present in every entry-point YAML) as a diagnostic text sensor.

--- a/espoolbuddy_console.yaml
+++ b/espoolbuddy_console.yaml
@@ -202,16 +202,16 @@ spi:
 # ============================================================================
 bambuddy_nfc:
   id: nfc_reader
-  api_id: bambuddy
+  api_id: bambuddy     # id of the bambuddy_api: component above (required link)
   spi_id: nfc_spi
   cs_pin: GPIO10
   irq_pin:
     number: GPIO14
     mode: INPUT_PULLUP  # PN532 IRQ is open-drain; pull-up required
-  data_rate: 1MHz
-  spi_mode: 0
+  data_rate: 1MHz      # PN532 SPI requirement — don't change without checking the datasheet
+  spi_mode: 0          # PN532 SPI requirement — mode 0 (CPOL=0, CPHA=0)
   poll_interval: 300   # ms — used only in fallback polling mode; IRQ mode uses 10ms guard
-  miss_threshold: 3
+  miss_threshold: 3    # consecutive no-tag responses before declaring tag removed
 
 
 # ============================================================================
@@ -327,27 +327,15 @@ rtttl:
 # ============================================================================
 bambuddy_api:
   id: bambuddy
-  backend_url: !secret bambuddy_backend_url
-  api_key: !secret bambuddy_api_key
-  hostname: "SpoolBuddy-Console"
-  backlight_id: display_backlight
-  # Optional hardware — omit either to build a console without a PN532/speaker;
-  # bambuddy_api gracefully no-ops the corresponding calls and hides the
-  # dependent Settings UI when not set.
-  nfc_id: nfc_reader
-  speaker_id: rtttl_player
-  # Which Bambuddy inventory backend to talk to — must match Settings → Spoolman
-  # in the Bambuddy web UI. "internal" (default) uses Bambuddy's own DB;
-  # "spoolman" delegates spool/tag/assignment calls to Bambuddy's Spoolman
-  # integration instead. Changing Bambuddy's setting later requires reflashing
-  # with the matching value here.
-  inventory_backend: internal   # internal | spoolman
+  backend_url: !secret bambuddy_backend_url   # Bambuddy server base URL, e.g. http://192.168.1.50:5000
+  api_key: !secret bambuddy_api_key           # from Bambuddy → Settings → Devices → this device's API key
+  hostname: "SpoolBuddy-Console"              # display name for this device in Bambuddy's device list (not the network/mDNS hostname)
+  backlight_id: display_backlight             # id of the `light:` below — dimmed/turned off by the sleep state machine
+  nfc_id: nfc_reader             # optional — omit for no PN532 (no-ops + hides Settings UI)
+  speaker_id: rtttl_player       # optional — omit for no speaker (no-ops + hides Settings UI)
+  inventory_backend: internal    # internal | spoolman — must match Bambuddy's Settings → Spoolman toggle (reflash if changed)
   heartbeat_interval: 10        # seconds — tag scan triggers an extra immediate heartbeat
-  scale_report_interval: 250    # ms
-  printer_poll_interval: 15     # seconds
-  # Deep-idle "sleep": sleep_timeout is controlled at runtime by the interval
-  # lambda in espoolbuddy/app.yaml (set_sleep_timeout from sleep_timeout_min
-  # global). sleep_factor stretches heartbeat + poll cadence while asleep.
-  sleep_factor: 12              # while asleep: heartbeat ×12 (10s→120s), poll ×12 (15s→180s)
-  # Header clock format: true = 24-hour (14:05), false = 12-hour (2:05 PM).
-  clock_24h: true
+  # heartbeat_fail_threshold: 3   # consecutive failed heartbeats before cloud/WiFi icons go red (default: 3)
+  printer_poll_interval: 15     # seconds between AMS/printer status polls to Bambuddy
+  sleep_factor: 12               # heartbeat/poll multiplier while asleep (×12: 10s→120s, 15s→180s); sleep_timeout set at runtime in app.yaml
+  clock_24h: true                # 24h format (false = 12h AM/PM)

--- a/espoolbuddy_console_pandatouch.yaml
+++ b/espoolbuddy_console_pandatouch.yaml
@@ -268,13 +268,13 @@ touchscreen:
 # ============================================================================
 bambuddy_api:
   id: bambuddy
-  backend_url: !secret bambuddy_backend_url
-  api_key: !secret bambuddy_api_key
-  hostname: "SpoolBuddy-Console-PandaTouch"
-  backlight_id: display_backlight
-  inventory_backend: internal
-  heartbeat_interval: 10
-  scale_report_interval: 250
-  printer_poll_interval: 15
-  sleep_factor: 12
-  clock_24h: true
+  backend_url: !secret bambuddy_backend_url   # Bambuddy server base URL, e.g. http://192.168.1.50:5000
+  api_key: !secret bambuddy_api_key           # from Bambuddy → Settings → Devices → this device's API key
+  hostname: "SpoolBuddy-Console-PandaTouch"   # display name for this device in Bambuddy's device list (not the network/mDNS hostname)
+  backlight_id: display_backlight             # id of the `light:` below — dimmed/turned off by the sleep state machine
+  inventory_backend: internal    # internal | spoolman — must match Bambuddy's Settings → Spoolman toggle (reflash if changed)
+  heartbeat_interval: 10        # seconds — tag scan triggers an extra immediate heartbeat
+  # heartbeat_fail_threshold: 3   # consecutive failed heartbeats before cloud/WiFi icons go red (default: 3)
+  printer_poll_interval: 15     # seconds between AMS/printer status polls to Bambuddy
+  sleep_factor: 12               # heartbeat/poll multiplier while asleep (×12: 10s→120s, 15s→180s); sleep_timeout set at runtime in app.yaml
+  clock_24h: true                # 24h format (false = 12h AM/PM)

--- a/espoolbuddy_scale.yaml
+++ b/espoolbuddy_scale.yaml
@@ -94,16 +94,12 @@ api:
 # ============================================================================
 bambuddy_api:
   id: bambuddy
-  # No backend_url / api_key — this device never contacts BamBuddy directly
-  hostname: "SpoolBuddy-Scale"
-  scale_mode: true    # starts HTTP server for tare/cal; persists cal in NVS
-  scale_report_interval: 100 # ms — weight push cadence to the console
-  # Push weight + NFC events to the console(s).
-  # Accepts either a single URL or a list of URLs. With multiple, the first
-  # is authoritative: only its heartbeat response is honored for tare/
-  # calibrate/write_tag commands and it alone drives the connectivity LED;
-  # any additional consoles are push-only observers of weight/NFC events.
-  console_url: "http://espoolbuddy-console.local"
+  # backend_url: ""              # not used in scale_mode — it runs its own HTTP server instead
+  # api_key: ""                  # not used in scale_mode — it runs its own HTTP server instead
+  hostname: "SpoolBuddy-Scale"  # display name sent with every push to the console (not the network/mDNS hostname)
+  scale_mode: true             # starts HTTP server for tare/cal; persists cal in NVS
+  scale_report_interval: 100   # ms — weight push cadence to the console
+  console_url: "http://espoolbuddy-console.local"   # or a list; first entry is authoritative for commands/LED, rest are push-only
   # console_url:
   #   - "http://espoolbuddy-console.local"
   #   - "http://espoolbuddy-console-2.local"
@@ -124,14 +120,14 @@ spi:
 # ============================================================================
 bambuddy_nfc:
   id: nfc_reader
-  api_id: bambuddy
+  api_id: bambuddy     # id of the bambuddy_api: component above (required link)
   spi_id: spi_bus
   cs_pin: GPIO18
   irq_pin:
     number: GPIO8
     mode: INPUT_PULLUP  # PN532 IRQ is open-drain; pull-up required
-  data_rate: 1MHz
-  spi_mode: 0
+  data_rate: 1MHz      # PN532 SPI requirement — don't change without checking the datasheet
+  spi_mode: 0          # PN532 SPI requirement — mode 0 (CPOL=0, CPHA=0)
   poll_interval: 300   # ms — used only in fallback polling mode; IRQ mode uses 10ms guard
   miss_threshold: 3    # consecutive no-tag responses before declaring tag removed
 


### PR DESCRIPTION
Retry once if the backend has closed the persistent connection in the meanwhile. 
Add theshold of default 3 failed heartbeats till the console shows the backend as offline.

Fixes #7 