### PR TITLE
Blank Panda Touch backlight during OTA to hide display glitching

### DIFF
--- a/.github/scripts/use_local_components.py
+++ b/.github/scripts/use_local_components.py
@@ -23,7 +23,8 @@ GIT_BLOCK = """external_components:
       url: https://github.com/CSchlipp/espoolbuddy.git
       ref: ${espoolbuddy_ref}
       path: components
-    components: [bambuddy_api, bambuddy_nfc]"""
+    components: [bambuddy_api, bambuddy_nfc]
+    refresh: always"""
 
 LOCAL_BLOCK = """external_components:
   - source:
@@ -36,7 +37,8 @@ PACKAGES_GIT_CONSOLE = """packages:
     url: https://github.com/CSchlipp/espoolbuddy.git
     ref: ${espoolbuddy_ref}
     path: espoolbuddy
-    files: [version.yaml, app.yaml, assets.yaml, lvgl.yaml]"""
+    files: [version.yaml, app.yaml, assets.yaml, lvgl.yaml]
+    refresh: always"""
 
 PACKAGES_LOCAL_CONSOLE = """packages:
   version: !include espoolbuddy/version.yaml
@@ -49,7 +51,8 @@ PACKAGES_GIT_SCALE = """packages:
     url: https://github.com/CSchlipp/espoolbuddy.git
     ref: ${espoolbuddy_ref}
     path: espoolbuddy
-    files: [version.yaml]"""
+    files: [version.yaml]
+    refresh: always"""
 
 PACKAGES_LOCAL_SCALE = """packages:
   version: !include espoolbuddy/version.yaml"""

--- a/espoolbuddy/version.yaml
+++ b/espoolbuddy/version.yaml
@@ -5,7 +5,7 @@
 # entry-point YAML so there is exactly one number to update.
 esphome:
   project:
-    version: "0.26.0"
+    version: "0.26.1"
 
 # Reports the same version to Home Assistant (via the native api: component,
 # already present in every entry-point YAML) as a diagnostic text sensor.

--- a/espoolbuddy_console.yaml
+++ b/espoolbuddy_console.yaml
@@ -88,6 +88,7 @@ external_components:
       ref: ${espoolbuddy_ref}
       path: components
     components: [bambuddy_api, bambuddy_nfc]
+    refresh: always
 
 packages:
   espoolbuddy:
@@ -95,6 +96,7 @@ packages:
     ref: ${espoolbuddy_ref}
     path: espoolbuddy
     files: [version.yaml, app.yaml, assets.yaml, lvgl.yaml]
+    refresh: always
 
 logger:
   # Global level must be DEBUG so the Bambuddy components can emit DEBUG (a

--- a/espoolbuddy_console_pandatouch.yaml
+++ b/espoolbuddy_console_pandatouch.yaml
@@ -83,6 +83,7 @@ external_components:
       ref: ${espoolbuddy_ref}
       path: components
     components: [bambuddy_api, bambuddy_nfc]
+    refresh: always
 
 packages:
   espoolbuddy:
@@ -90,6 +91,7 @@ packages:
     ref: ${espoolbuddy_ref}
     path: espoolbuddy
     files: [version.yaml, app.yaml, assets.yaml, lvgl.yaml]
+    refresh: always
 
 logger:
   # Global level must be DEBUG so the Bambuddy components can emit DEBUG (a
@@ -131,6 +133,19 @@ captive_portal:
 ota:
   - platform: esphome
     password: !secret ota_password
+    # This board drives its RGB panel directly from a continuously-scanned
+    # PSRAM framebuffer; a stalled main loop during the flash write shows up
+    # as visible glitching. Blank the backlight for the duration so nothing
+    # is visible, and restore it on any outcome that doesn't reboot.
+    on_begin:
+      - lambda: |-
+          id(backlight_pwm).set_level(0.0f);
+    on_error:
+      - lambda: |-
+          id(backlight_pwm).set_level(id(backlight_brightness_pct) / 100.0f);
+    on_abort:
+      - lambda: |-
+          id(backlight_pwm).set_level(id(backlight_brightness_pct) / 100.0f);
 
 api:
   encryption:

--- a/espoolbuddy_scale.yaml
+++ b/espoolbuddy_scale.yaml
@@ -53,6 +53,7 @@ external_components:
       ref: ${espoolbuddy_ref}
       path: components
     components: [bambuddy_api, bambuddy_nfc]
+    refresh: always
 
 packages:
   espoolbuddy:
@@ -60,6 +61,7 @@ packages:
     ref: ${espoolbuddy_ref}
     path: espoolbuddy
     files: [version.yaml]
+    refresh: always
 
 logger:
   level: INFO


### PR DESCRIPTION
This board drives its RGB panel directly from a continuously-scanned PSRAM framebuffer; a stalled main loop during the OTA flash write shows up as visible glitching. Cut the backlight to 0% on OTA start and restore it on error/abort (a successful OTA reboots immediately after, so hardware reinitializes fresh). WT32-SC01 console is unaffected since it pushes frames on demand over SPI rather than continuous DMA scan.