### PR TITLE
Fix AMS tab stuck on "No printer selected" after Bambuddy update

### DIFF
--- a/espoolbuddy/app.yaml
+++ b/espoolbuddy/app.yaml
@@ -1111,7 +1111,8 @@ interval:
             uint32_t sig = (uint32_t)n_ams * 2654435761u ^ (uint32_t)s.dual_nozzle
                          ^ ((uint32_t)id(ams_page) * 2246822519u)
                          ^ ((uint32_t)id(ams_rows_per_page) * 3266489917u)  // Settings row-count change
-                         ^ ((uint32_t)s.tray_now   * 1500450271u);  // active spool highlight
+                         ^ ((uint32_t)s.tray_now   * 1500450271u)  // active spool highlight
+                         ^ ((uint32_t)s.printers.size() * 16777619u);  // "No printer selected" vs "No AMS data"
             for (int ui = 0; ui < n_ams; ui++) {
               const auto &u = s.ams_units[ui];
               sig ^= ((uint32_t)u.id * 40503u) ^ ((uint32_t)u.trays.size() * 6700417u)

--- a/espoolbuddy/version.yaml
+++ b/espoolbuddy/version.yaml
@@ -5,7 +5,7 @@
 # entry-point YAML so there is exactly one number to update.
 esphome:
   project:
-    version: "0.26.1"
+    version: "0.26.2"
 
 # Reports the same version to Home Assistant (via the native api: component,
 # already present in every entry-point YAML) as a diagnostic text sensor.


### PR DESCRIPTION
When the backend is updated and the selected printer has not been powered on since, /printers/{id}/status returns a partial payload (connected:false, ams:[], tray_now:255). The AMS tab's empty-state label is only rewritten inside the render dirty-check, whose change signature was built from AMS data only -- not the printer list. 
So the label painted "No printer selected" on the first frame (before the first poll completed) stayed frozen even after the printer list populated, because every other signature input was held constant by the partial response. A tab switch and back was the only way to force the re-render.

Fold s.printers.size() into the signature so the label re-evaluates to "No AMS data" as soon as the printer list loads.

Bump version to 0.26.2.