### PR TITLE
Don't feed the task watchdog from the scale-push HTTP task

### DIFF
--- a/components/bambuddy_api/bambuddy_api.cpp
+++ b/components/bambuddy_api/bambuddy_api.cpp
@@ -1735,8 +1735,11 @@ bool BambuddyAPIComponent::http_request(esp_http_client_method_t method,
       ESP_LOGD(TAG, "    body: %s", json_body.c_str());
     }
 
-    // Feed the task WDT immediately before the blocking HTTP call.
-    arch_feed_wdt();
+    // Feed the task WDT immediately before the blocking HTTP call — but only in
+    // console mode.  The scale-push task is deliberately not subscribed to the
+    // TWDT (see http_task_loop), so arch_feed_wdt() -> esp_task_wdt_reset() there
+    // just spams "task not found" on every heartbeat.
+    if (!scale_mode_) arch_feed_wdt();
     esp_err_t err = esp_http_client_perform(client);
     int status = esp_http_client_get_status_code(client);
 

--- a/espoolbuddy/version.yaml
+++ b/espoolbuddy/version.yaml
@@ -5,7 +5,7 @@
 # entry-point YAML so there is exactly one number to update.
 esphome:
   project:
-    version: "0.27.0"
+    version: "0.27.1"
 
 # Reports the same version to Home Assistant (via the native api: component,
 # already present in every entry-point YAML) as a diagnostic text sensor.


### PR DESCRIPTION
http_request() calls arch_feed_wdt() before its blocking HTTP call, but the
scale-push worker task is deliberately not subscribed to the ESP-IDF task
watchdog (it can block ~30s in mDNS resolution). esp_task_wdt_reset() from
an unsubscribed task logs "E task_wdt: esp_task_wdt_reset(): task not found"
on every heartbeat. Guard the feed with !scale_mode.

Bump version to 0.27.1.